### PR TITLE
Updated error message about sources for API files and "apis" property

### DIFF
--- a/bin/swagger-jsdoc.js
+++ b/bin/swagger-jsdoc.js
@@ -66,7 +66,7 @@ if (
 if (!program.args.length) {
   console.log('You must provide sources for reading API files.');
   console.log(
-    'Either add filenames as arguments, or add an "apis" key in your configuration.'
+    'Add filenames as arguments (note that the "apis" key in the configuration is not read anymore).'
   );
   process.exit();
 }


### PR DESCRIPTION
Hi,

The error message returned to user using the deprecated "apis" property was not helpful.
It was still refering to the "apis" property in config while it is not read anymore.